### PR TITLE
Default to project_data `projectTypes` if it exists

### DIFF
--- a/OpenSesame.py
+++ b/OpenSesame.py
@@ -77,7 +77,14 @@ class OpenSesameCommand(sublime_plugin.TextCommand):
 
 		# Get project type
 		project_type_key = self.project_data.get('projectType');
-		project_type = self.plugin_settings.get('projectTypes').get(project_type_key);
+
+		project_type = None
+
+		if self.project_data.get('projectTypes'):
+			project_type = self.project_data.get('projectTypes').get(project_type_key)
+
+		if project_type is None:
+			project_type = self.plugin_settings.get('projectTypes').get(project_type_key);
 
 		if project_type is None:
 			sublime.set_timeout(lambda: window.show_quick_panel([['OpenSesame Error', 'Cannot find project type: ' + project_type_key]], None), 10)


### PR DESCRIPTION
Allows user to define their own `projectTypes` object in `.open-sesame`.

E.g.

```
"projectType": "my_project_type",
"projectTypes": {
    "my_project_type": {
         "files": [
             "*.jsx",
             "*.css",
             "*.spec.js"
         ],
         "layout": {
             "cols": [0.0, 0.5, 1.0],
             "rows": [0.0, 0.5, 1.0],
             "cells": [
                 [0, 0, 1, 2],
                 [1, 0, 2, 1],
                 [1, 1, 2, 2]
             ]
         }
     }
}
```